### PR TITLE
docs: improve GSC setup reliability and clarity (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.2] — 2026-03-27
+
+### Changed
+- **`seo-analysis` Phase 1** — replaced two-step auth check (token print + separate site list) with single `list_gsc_sites.py` call that tests auth, scopes, and GSC access in one shot; added distinct handling for each failure mode (wrong account, wrong scopes, API not enabled, gcloud not installed)
+- **`seo-analysis` script paths** — replaced hardcoded `~/.claude/skills/seo-analysis/scripts/` with a `find`-based `SKILL_SCRIPTS` lookup that works for Claude Code, Codex, and custom install paths
+- **`seo-analysis` property selection** — added explicit rule to prefer domain property (`sc-domain:example.com`) over URL-prefix when both exist for the same site
+- **`gsc_setup.md`** — moved "Which Google Account" guidance to top (most common failure cause); replaced broken `oauth_setup.py` Option B with Linux (Debian/Ubuntu, RPM) and Windows install instructions; fixed deprecated `apt-key` with `gpg --dearmor` for Debian 12+/Ubuntu 24.04+; expanded troubleshooting to cover `insufficient_scope` 403s
+
+### Fixed
+- **`list_gsc_sites.py`** — unhandled `FileNotFoundError` when gcloud is not installed now shows a clean error message instead of a Python traceback
+- **`analyze_gsc.py`** — same `FileNotFoundError` fix
+- **`gsc_setup.md`** — removed reference to `oauth_setup.py` which did not exist
+
+---
+
 ## [0.1.1] — 2026-03-27
 
 ### Changed

--- a/seo-analysis/SKILL.md
+++ b/seo-analysis/SKILL.md
@@ -31,28 +31,56 @@ cold.
 
 ## Phase 1 — Confirm Access to Google Search Console
 
-Check silently:
+Locate the scripts directory (works regardless of where the skill is installed):
 
 ```bash
-gcloud auth application-default print-access-token 2>&1
+SKILL_SCRIPTS=$(find ~/.claude/skills ~/.codex/skills .agents/skills -type d -name scripts -path "*seo-analysis*" 2>/dev/null | head -1)
+echo "Scripts at: $SKILL_SCRIPTS"
 ```
 
-**If this succeeds** (returns a token): proceed to Phase 2.
+Run the site listing script as a single combined auth + access check:
 
-**If this fails**: ask the user which situation applies:
-- "I have gcloud installed but haven't set it up for GSC"
-- "I don't have gcloud"
-- "Skip GSC — just do a technical crawl audit of my URL"
+```bash
+python3 "$SKILL_SCRIPTS/list_gsc_sites.py"
+```
 
-Then guide accordingly — read `references/gsc_setup.md` for the full setup guide.
+This tests everything at once: whether gcloud exists, whether ADC is authenticated
+with the right scopes, and whether the authenticated account actually has GSC access.
 
-The most common case is gcloud already installed. In that case, run:
+**If it lists sites** → you're done; carry the site list into Phase 2 (skip running
+list_gsc_sites.py again).
+
+**If "No Search Console properties found"** → the authenticated account has no GSC
+properties. Most likely cause: gcloud is set up for the wrong Google account (work
+email vs personal, different org). But also possible: the site was never added to
+Search Console, or the user's access was revoked. Ask: "Which Google account has
+access to your Search Console? Go to https://search.google.com/search-console and
+check which account you're logged in as — that's the one to use." Then re-authenticate:
 ```bash
 gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/webmasters.readonly
 ```
-This opens a browser, the user logs in with the Google account that owns Search
-Console, and that's it. No service accounts, no JSON files.
+
+**If "Could not get access token"** (gcloud not authenticated or wrong scopes) → run:
+```bash
+gcloud auth application-default login \
+  --scopes=https://www.googleapis.com/auth/webmasters.readonly
+```
+This is the common case where gcloud is installed but was set up for a different
+service (Firebase, GCS, etc.) without the webmasters scope. The browser opens,
+the user logs in, done.
+
+**If Python traceback mentioning "No such file or directory" or "gcloud"** → gcloud
+isn't installed (the script couldn't launch it). Ask if they want to install it
+(2 min) or skip GSC entirely. Read `references/gsc_setup.md` for install steps. If
+they want to skip: jump to Phase 5 (technical-only audit).
+
+**If HTTP 403** → could be wrong scopes, API not enabled, or no property access.
+Check the error body: "insufficient scope" → re-run `gcloud auth application-default
+login --scopes=...`; "API not enabled" → run `gcloud services enable
+searchconsole.googleapis.com`; "permission denied" → the account doesn't have GSC
+access for this property (verify at https://search.google.com/search-console →
+Settings → Users and permissions). Full details in `references/gsc_setup.md`.
 
 ---
 
@@ -76,15 +104,18 @@ Confirm with the user: "I found your site at `https://example.com` — is that r
 Ask: "What's your website URL? (e.g. https://yoursite.com)"
 
 ### Match to GSC property
-List the user's GSC properties and find the match:
+If Phase 1 already listed the user's GSC properties, use that output. Otherwise
+re-run (e.g., if GSC was skipped and the user has since authenticated):
 
 ```bash
-python3 "$(dirname "$0")/scripts/list_gsc_sites.py"
+python3 "$SKILL_SCRIPTS/list_gsc_sites.py"
 ```
 
 GSC properties can be domain properties (`sc-domain:example.com`) or URL-prefix
-properties (`https://example.com/`). The script handles both. If multiple matches
-exist, ask the user to confirm which one to use.
+properties (`https://example.com/`). The script handles both. If both a domain
+property and a URL-prefix property exist for the same site, prefer the domain
+property — it covers all subdomains, protocols, and subpaths, giving more complete
+data. If multiple matches exist and it's still ambiguous, ask the user to confirm.
 
 ---
 
@@ -93,7 +124,7 @@ exist, ask the user to confirm which one to use.
 Run the main analysis script with the confirmed site property:
 
 ```bash
-python3 "$(dirname "$0")/scripts/analyze_gsc.py" \
+python3 "$SKILL_SCRIPTS/analyze_gsc.py" \
   --site "sc-domain:example.com" \
   --days 90
 ```

--- a/seo-analysis/references/gsc_setup.md
+++ b/seo-analysis/references/gsc_setup.md
@@ -1,5 +1,21 @@
 # Google Search Console API Setup Guide
 
+## Step 0 — Which Google Account Has GSC Access?
+
+This is the most common source of confusion. You need to authenticate with the
+**exact Google account** that has access to Search Console for this site.
+
+Check which account it is:
+1. Go to https://search.google.com/search-console
+2. Note which Google account you're logged in as (top-right corner)
+3. Use that same account in all the steps below
+
+If you have multiple Google accounts (work email, personal Gmail, different org),
+make sure you pick the right one. A valid gcloud token from the wrong account will
+appear to work but return no GSC properties.
+
+---
+
 ## The Fastest Path: gcloud Application Default Credentials
 
 If gcloud is installed, this is a single command:
@@ -9,22 +25,23 @@ gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/webmasters.readonly
 ```
 
-A browser window opens. Log in with the Google account that has access to Search Console for the site. Done. The token is stored at `~/.config/gcloud/application_default_credentials.json` and auto-refreshes.
+A browser window opens. Log in with the Google account from Step 0. Done. The
+token auto-refreshes and is stored at
+`~/.config/gcloud/application_default_credentials.json`.
 
-**Verify it worked:**
+**Verify it worked** (should list your GSC properties):
 ```bash
-gcloud auth application-default print-access-token
+SKILL_SCRIPTS=$(find ~/.claude/skills ~/.codex/skills .agents/skills -type d -name scripts -path "*seo-analysis*" 2>/dev/null | head -1)
+python3 "$SKILL_SCRIPTS/list_gsc_sites.py"
 ```
-Should print a long token string (not an error).
 
 ---
 
 ## If gcloud Is Not Installed
 
-### Option A: Install gcloud (recommended, ~5 min)
+### macOS (Homebrew)
 
 ```bash
-# macOS with Homebrew
 brew install google-cloud-sdk
 
 # Then authenticate
@@ -32,33 +49,57 @@ gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/webmasters.readonly
 ```
 
-### Option B: OAuth Desktop App Flow (no gcloud)
+### Linux (Debian/Ubuntu)
 
-1. Go to https://console.cloud.google.com/
-2. Create a new project (or use an existing one)
-3. Enable the **Google Search Console API**:
-   - Go to APIs & Services → Library
-   - Search "Search Console API" → Enable
-4. Create credentials:
-   - Go to APIs & Services → Credentials
-   - Create credentials → OAuth client ID
-   - Application type: Desktop app
-   - Download the JSON file as `credentials.json`
-5. Run the auth flow:
-   ```bash
-   python3 /path/to/skills/seo-analysis/scripts/oauth_setup.py \
-     --credentials credentials.json
-   ```
-   This opens a browser, you authorize, and a `token.json` is saved.
+```bash
+# Install prerequisites (curl may already be present)
+sudo apt-get install -y curl apt-transport-https ca-certificates gnupg
 
----
+# Add the Google Cloud GPG key (modern keyring method, works on Debian 12+/Ubuntu 22.04+)
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
-## Checking Which Google Account Has GSC Access
+# Add the Cloud SDK apt repository
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
+  https://packages.cloud.google.com/apt cloud-sdk main" \
+  | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
 
-Not sure which account has Search Console access? Check at:
-https://search.google.com/search-console
+sudo apt-get update && sudo apt-get install -y google-cloud-cli
 
-The account you log in with there is the one to use for `gcloud auth application-default login`.
+# Then authenticate
+gcloud auth application-default login \
+  --scopes=https://www.googleapis.com/auth/webmasters.readonly
+```
+
+### Linux (RPM/Fedora/RHEL)
+
+```bash
+sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+[google-cloud-cli]
+name=Google Cloud CLI
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+sudo dnf install google-cloud-cli
+
+# Then authenticate
+gcloud auth application-default login \
+  --scopes=https://www.googleapis.com/auth/webmasters.readonly
+```
+
+### Windows
+
+Download and run the installer from:
+https://cloud.google.com/sdk/docs/install#windows
+
+Then in PowerShell:
+```powershell
+gcloud auth application-default login `
+  --scopes=https://www.googleapis.com/auth/webmasters.readonly
+```
 
 ---
 
@@ -75,15 +116,27 @@ Domain properties are better (more complete data). The analysis scripts handle b
 
 ## Troubleshooting
 
-**"Access Not Configured" error**: The Search Console API isn't enabled in your GCP project. Run:
+**"No Search Console properties found"**: gcloud is working but the wrong Google
+account is authenticated. Re-run `gcloud auth application-default login` and log
+in with the account that has GSC access (see Step 0 above).
+
+**"Access Not Configured" / HTTP 403 with "API not enabled"**: The Search Console
+API isn't enabled in your GCP project. Run:
 ```bash
 gcloud services enable searchconsole.googleapis.com
 ```
 
-**"The caller does not have permission" error**: The authenticated account doesn't have access to the GSC property. Verify at https://search.google.com/search-console → Settings → Users and permissions.
+**"The caller does not have permission"**: The authenticated account doesn't have
+access to the specific GSC property. Verify at
+https://search.google.com/search-console → Settings → Users and permissions.
 
-**Token expired**: ADC tokens auto-refresh. If you get auth errors, re-run:
+**"insufficient_scope" or 403 on API calls despite valid token**: You have ADC
+configured for a different Google service (Firebase, GCS, BigQuery, etc.) without
+the `webmasters.readonly` scope. Re-run:
 ```bash
 gcloud auth application-default login \
   --scopes=https://www.googleapis.com/auth/webmasters.readonly
 ```
+
+**Token expired**: ADC tokens auto-refresh. If you get persistent auth errors,
+re-run the `gcloud auth application-default login` command above.

--- a/seo-analysis/scripts/analyze_gsc.py
+++ b/seo-analysis/scripts/analyze_gsc.py
@@ -19,10 +19,15 @@ from datetime import date, timedelta
 
 
 def get_access_token():
-    result = subprocess.run(
-        ["gcloud", "auth", "application-default", "print-access-token"],
-        capture_output=True, text=True
-    )
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        print("ERROR: gcloud not found. Install it and authenticate:", file=sys.stderr)
+        print("  https://cloud.google.com/sdk/docs/install", file=sys.stderr)
+        sys.exit(1)
     if result.returncode != 0:
         print("ERROR: Not authenticated. Run:", file=sys.stderr)
         print("  gcloud auth application-default login \\", file=sys.stderr)

--- a/seo-analysis/scripts/list_gsc_sites.py
+++ b/seo-analysis/scripts/list_gsc_sites.py
@@ -9,10 +9,15 @@ import urllib.error
 
 
 def get_access_token():
-    result = subprocess.run(
-        ["gcloud", "auth", "application-default", "print-access-token"],
-        capture_output=True, text=True
-    )
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        print("ERROR: gcloud not found. Install it and authenticate:", file=sys.stderr)
+        print("  https://cloud.google.com/sdk/docs/install", file=sys.stderr)
+        sys.exit(1)
     if result.returncode != 0:
         print("ERROR: Could not get access token. Run:", file=sys.stderr)
         print("  gcloud auth application-default login \\", file=sys.stderr)


### PR DESCRIPTION
## Summary

**Error handling**
- `list_gsc_sites.py` and `analyze_gsc.py` now catch `FileNotFoundError` when gcloud is not installed — users see a clean error message with an install link instead of a Python traceback

**seo-analysis skill (Phase 1)**
- Replaced two-step auth check (token print → separate site list) with a single `list_gsc_sites.py` call that tests auth, scopes, and GSC access in one shot
- Added distinct recovery paths for each failure mode: wrong account, wrong scopes (insufficient_scope), API not enabled, gcloud not installed
- Replaced hardcoded `~/.claude/skills/seo-analysis/scripts/` paths with a `find`-based `SKILL_SCRIPTS` lookup — works for Claude Code, Codex, and custom install paths

**seo-analysis skill (Phase 2)**
- Added explicit rule: prefer domain property (`sc-domain:example.com`) over URL-prefix when both exist for the same site

**gsc_setup.md**
- Moved "Which Google Account" section to the top — this is the #1 cause of setup failures
- Added Linux (Debian/Ubuntu + RPM) and Windows install instructions
- Fixed deprecated `apt-key` with `gpg --dearmor` (Debian 12+/Ubuntu 24.04+ compatibility)
- Expanded troubleshooting to distinguish `insufficient_scope` 403s from `API not enabled` and `no permission` 403s
- Removed reference to `oauth_setup.py` which did not exist

## Test Coverage

No test framework configured. Python changes are pure `try/except FileNotFoundError` additions — no logic branches, no data transformation.

## Pre-Landing Review

6 issues found and resolved (0 critical, 6 informational). All auto-fixed or user-approved. Review ran clean.

## Design Review

No frontend files changed — design review skipped.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan
- [x] Pre-landing review: clean (6 informational issues, all resolved)
- [x] Adversarial review (Codex): 6 issues found, all addressed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)