### PR TITLE
fix: surface business context requests in weekly reviews

### DIFF
--- a/openclaw/bin/weekly_review.py
+++ b/openclaw/bin/weekly_review.py
@@ -1345,8 +1345,56 @@ def run_analysis(site_property: str, days: int, brand_terms: str | None) -> dict
     cmd = [sys.executable, str(ANALYZE_GSC), "--site", site_property, "--days", str(days), "--output", str(output_path)]
     if brand_terms:
         cmd.extend(["--brand-terms", brand_terms])
-    subprocess.run(cmd, check=True)
+    completed = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    if completed.stdout:
+        print(completed.stdout, file=sys.stderr, end="")
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="")
     return json.loads(output_path.read_text())
+
+
+def build_user_message(site_id: str, result: dict[str, Any], payload: dict[str, Any], context_request: dict[str, Any] | None) -> str:
+    summary = payload.get("state_snapshot", {}).get("summary") or "Weekly review complete."
+    actions = (payload.get("action_plan") or {}).get("actions") or []
+    top_action = actions[0] if actions else {}
+    queue_items = result.get("queue_items_written") or []
+    proposal_path = next((path for path in queue_items if "/proposal_" in path), None)
+    lines = [
+        f"Weekly SEO review complete for `{site_id}`.",
+        "",
+        f"Run: `{result.get('run_dir')}`",
+        f"Summary: {summary}",
+    ]
+    if top_action:
+        lines.extend([
+            "",
+            "Top proposed next action:",
+            f"- Type: `{top_action.get('type')}`",
+            f"- Target: `{top_action.get('target')}`",
+            f"- Why: {top_action.get('expected_impact')}",
+            f"- Requires approval: {'yes' if top_action.get('requires_approval') else 'no'}",
+        ])
+        deep_dive = top_action.get("deep_dive") or {}
+        checks = deep_dive.get("checks") or {}
+        if deep_dive:
+            lines.append(
+                f"- Deep dive: {deep_dive.get('status')} "
+                f"(SERP {'yes' if checks.get('serp_inspected') else 'no'}, "
+                f"snippet {'yes' if checks.get('current_snippet_inspected') else 'no'}, "
+                f"above-fold {'yes' if checks.get('above_the_fold_inspected') else 'no'})"
+            )
+    if proposal_path:
+        lines.extend(["", f"Proposal file: `{proposal_path}`"])
+    if context_request:
+        questions = context_request.get("business_context_questions") or []
+        score = context_request.get("business_context_score")
+        percent = round(float(score or 0) * 100)
+        lines.extend([
+            "",
+            f"Before I can recommend/approve edits, business context is only {percent}% complete. Please answer these, roughly is fine:",
+        ])
+        lines.extend(f"{idx}. {question}" for idx, question in enumerate(questions, start=1))
+    return "\n".join(lines)
 
 
 def main(argv: list[str]) -> int:
@@ -1390,6 +1438,7 @@ def main(argv: list[str]) -> int:
             "output_path": context_request["output_path"],
             "questions": context_request["business_context_questions"],
         }
+    result["user_message"] = build_user_message(site_id, result, payload, context_request)
     print(json.dumps(result, indent=2))
     return 0
 

--- a/openclaw/install/install-openclaw-cron.sh
+++ b/openclaw/install/install-openclaw-cron.sh
@@ -150,7 +150,7 @@ for i in "${!sites[@]}"; do
   # Cron day-of-week: 1=Monday. Spread sites across weekdays, then wrap.
   dow=$(( (i % 5) + 1 ))
   cron_expr="$minute $hour * * $dow"
-  weekly_msg="Run the automated Toprank weekly SEO review for $site. Execute exactly: TOPRANK_OPENCLAW_HOME=\"$RUNTIME_HOME\" python3 \"$REPO_ROOT/openclaw/bin/weekly_review.py\" \"$site\". Then inspect the generated run_dir from stdout. Summarize the top issue, proposed next action, whether it requires approval, and the artifact path. Do not edit websites, CMS, repos, or publish anything. If the command fails, report the blocker."
+  weekly_msg="Run the automated Toprank weekly SEO review for $site. Execute exactly: TOPRANK_OPENCLAW_HOME=\"$RUNTIME_HOME\" python3 \"$REPO_ROOT/openclaw/bin/weekly_review.py\" \"$site\". Parse the JSON stdout. If it contains user_message, send that user_message to the user as the main visible update. If business_context_request is present, explicitly ask those questions; do not bury them behind artifact paths. Otherwise summarize the top issue, proposed next action, whether it requires approval, and the artifact path. Do not edit websites, CMS, repos, or publish anything. If the command fails, report the blocker."
 
   weekly_args=(
     --cron "$cron_expr"

--- a/openclaw/skills/toprank-weekly-review/SKILL.md
+++ b/openclaw/skills/toprank-weekly-review/SKILL.md
@@ -18,7 +18,8 @@ metadata: { "openclaw": { "emoji": "📈", "homepage": "https://github.com/nowor
    - add `--analysis-file` when testing against a saved GSC analysis JSON fixture
 8. The runner will generate and persist the review artifacts automatically, including automatic deep-dive diagnostics for the top CTR/snippet/content opportunity when applicable.
 9. Verify that the run wrote `audit.json`, `action-plan.json`, and `verification.json`, refreshed `latest-state.json`, and created queue items. The top proposal should include `deep_dive` with SERP, current snippet, above-the-fold, and zero-click checks before approval.
-10. If the next action requires editing a site repo, CMS, publishing content, or opening a PR, stop and ask for approval before doing it. Missing business context blocks approval/editing, not investigation.
+10. If runner stdout includes `user_message`, use it as the user-facing summary. If it includes `business_context_request`, explicitly ask those questions in chat; do not just report artifact paths or say business context is incomplete.
+11. If the next action requires editing a site repo, CMS, publishing content, or opening a PR, stop and ask for approval before doing it. Missing business context blocks approval/editing, not investigation.
 
 ## Wrapper job
 


### PR DESCRIPTION
## Summary
- adds a user-facing weekly review message that includes the top proposal and business-context questions
- keeps weekly_review stdout parseable JSON by forwarding GSC analysis logs to stderr
- updates cron/skill instructions to ask business-context questions instead of burying them in artifact paths

## Verification
- python3 -m unittest openclaw.tests.test_weekly_review_scoring
- python3 -m compileall -q openclaw/bin/weekly_review.py
- smoke-ran weekly_review.py pawsvip.com and verified JSON contains user_message + business_context_request
