### PR TITLE
Align weekly reviews with SEO best practices

### DIFF
--- a/openclaw/bin/weekly_review.py
+++ b/openclaw/bin/weekly_review.py
@@ -32,6 +32,90 @@ ANALYZE_GSC = Path(__file__).resolve().parents[2] / "seo" / "seo-analysis" / "sc
 DEFAULT_PRIMARY_METRIC = "non_brand_clicks_28d"
 
 
+SEO_BEST_PRACTICE_REFERENCE = "seo/shared/seo-best-practices.md"
+SEO_BEST_PRACTICE_AREAS: dict[str, dict[str, Any]] = {
+    "search_eligibility_indexability": {
+        "label": "Search eligibility & indexability",
+        "resources": [
+            "Google Search Essentials",
+            "Google Search Central SEO Starter Guide",
+        ],
+        "why": "Google must be able to discover, crawl, render, canonicalize, and index the right URL before content changes can work.",
+    },
+    "demand_intent_targeting": {
+        "label": "Demand & intent targeting",
+        "resources": [
+            "Ahrefs Beginner’s Guide to SEO",
+            "Moz Beginner’s Guide to SEO",
+            "Google helpful content guidance",
+        ],
+        "why": "The operator should first choose the valuable search demand and map each query intent to the page that should own it.",
+    },
+    "content_usefulness_trust": {
+        "label": "Content usefulness & trust",
+        "resources": [
+            "Google helpful, reliable, people-first content guidance",
+            "Google Search Quality concepts: E-E-A-T",
+        ],
+        "why": "Pages need original, complete, trustworthy information that satisfies the searcher, not just search-engine-first copy.",
+    },
+    "on_page_relevance_serp_packaging": {
+        "label": "On-page relevance & SERP packaging",
+        "resources": [
+            "Google Search Central SEO Starter Guide",
+            "Google structured data documentation",
+            "Moz Beginner’s Guide to SEO",
+        ],
+        "why": "Titles, headings, snippets, structured data, and above-the-fold packaging help users and search engines understand why the page is the right result.",
+    },
+    "technical_ux_page_experience": {
+        "label": "Technical UX & page experience",
+        "resources": [
+            "Google page experience documentation",
+            "Google Core Web Vitals guidance",
+        ],
+        "why": "Fast, secure, mobile-friendly, non-intrusive pages support better user outcomes and can contribute when helpful content is otherwise competitive.",
+    },
+    "authority_distribution": {
+        "label": "Authority & distribution",
+        "resources": [
+            "Ahrefs link building guidance",
+            "Moz link building guidance",
+            "Google Search Essentials promotion guidance",
+        ],
+        "why": "Competitive topics often need internal link equity, citations, mentions, or other legitimate reputation signals beyond page-level copy.",
+    },
+    "local_presence_reputation": {
+        "label": "Local presence & reputation",
+        "resources": [
+            "Google Business Profile local ranking guidance",
+            "Ahrefs local SEO guidance",
+        ],
+        "why": "Local rankings depend on relevance, distance, and prominence, including complete business information, reviews, photos, and locally specific proof.",
+    },
+    "measurement_prioritization_experimentation": {
+        "label": "Measurement, prioritization & experimentation",
+        "resources": [
+            "Google Search Central measurement guidance",
+            SEO_BEST_PRACTICE_REFERENCE,
+        ],
+        "why": "SEO work should be prioritized by expected business impact, measured against baselines, and followed up after enough data matures.",
+    },
+}
+
+ACTION_BEST_PRACTICE_AREAS = {
+    "canonical_or_tracking_investigation": "search_eligibility_indexability",
+    "query_intent_mapping": "demand_intent_targeting",
+    "local_intent_ownership": "demand_intent_targeting",
+    "content_refresh": "content_usefulness_trust",
+    "page_improvement": "content_usefulness_trust",
+    "meta_tags": "on_page_relevance_serp_packaging",
+    "snippet_content_packaging": "on_page_relevance_serp_packaging",
+    "internal_links": "authority_distribution",
+    "manual_review": "measurement_prioritization_experimentation",
+}
+
+
 def future_iso(days: int) -> str:
     return (datetime.now(timezone.utc) + timedelta(days=days)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -194,6 +278,43 @@ def make_issue(
     return issue
 
 
+def best_practice_alignment_for_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    """Attach the primary MECE SEO best-practice lane for operator review."""
+    action_type = str(issue.get("recommended_action_type") or "manual_review")
+    area_key = ACTION_BEST_PRACTICE_AREAS.get(action_type)
+    if area_key is None:
+        return {
+            "reference": SEO_BEST_PRACTICE_REFERENCE,
+            "primary_area": "unmapped",
+            "primary_area_label": "Unmapped SEO action type",
+            "resources": [SEO_BEST_PRACTICE_REFERENCE],
+            "notes": [
+                f"Action type '{action_type}' is not mapped to a MECE SEO best-practice lane.",
+                "Downgrade to investigation/manual review or update ACTION_BEST_PRACTICE_AREAS before treating this as an approved recommendation.",
+            ],
+        }
+
+    area = SEO_BEST_PRACTICE_AREAS[area_key]
+    notes = [area["why"]]
+
+    if action_type in {"meta_tags", "snippet_content_packaging"}:
+        notes.append("Validate the query/page/SERP fit before treating low CTR as a title or meta-description problem.")
+    elif action_type in {"query_intent_mapping", "local_intent_ownership"}:
+        notes.append("Resolve search intent ownership before changing content, redirects, canonicals, or metadata.")
+    elif action_type == "page_improvement":
+        notes.append("A regression is a diagnosis trigger; inspect content usefulness, SERP changes, and technical access before publishing edits.")
+    elif action_type == "internal_links":
+        notes.append("Use relevant internal links to clarify page ownership and distribute authority; do not jump straight to redirects.")
+    elif action_type == "canonical_or_tracking_investigation":
+        notes.append("Canonical/tracking variants should be investigated as URL hygiene before editing page copy.")
+
+    return {
+        "reference": SEO_BEST_PRACTICE_REFERENCE,
+        "primary_area": area_key,
+        "primary_area_label": area["label"],
+        "resources": area["resources"],
+        "notes": notes,
+    }
 
 
 
@@ -1203,6 +1324,7 @@ def build_payload(
             **issue,
             "priority_score": issue.get("priority_score", round(issue.get("base_priority", 0.3), 3)),
             "learned_multiplier": issue.get("learned_multiplier", 1.0),
+            "best_practice_alignment": best_practice_alignment_for_issue(issue),
         }
         for issue in top_issues
     ]
@@ -1241,6 +1363,7 @@ def build_payload(
                 "operator_judgment_notes": issue.get("operator_judgment_notes", []),
                 "deep_dive": issue.get("deep_dive"),
                 "business_context_adjustment": issue.get("business_context_adjustment"),
+                "best_practice_alignment": issue.get("best_practice_alignment"),
                 "consolidation_targets": issue.get("consolidation_targets"),
                 "source_target": issue.get("source_target"),
                 "needs_business_context": context_check["score"] < 0.75,
@@ -1270,6 +1393,7 @@ def build_payload(
                     "operator_judgment_notes": issue.get("operator_judgment_notes", []),
                     "deep_dive": issue.get("deep_dive"),
                     "business_context_adjustment": issue.get("business_context_adjustment"),
+                    "best_practice_alignment": issue.get("best_practice_alignment"),
                     "consolidation_targets": issue.get("consolidation_targets"),
                     "source_target": issue.get("source_target"),
                     "business_context_score": context_check["score"],
@@ -1327,6 +1451,13 @@ def build_payload(
                     "checks": top_issues[0].get("deep_dive", {}).get("checks", {}),
                 },
                 {
+                    "name": "best practice alignment",
+                    "status": "pass" if top_issues[0].get("best_practice_alignment", {}).get("primary_area") not in {None, "", "unmapped"} else "warning",
+                    "notes": top_issues[0].get("best_practice_alignment", {}).get("primary_area_label", "Top recommendation is not mapped to a MECE SEO best-practice lane."),
+                    "reference": SEO_BEST_PRACTICE_REFERENCE,
+                    "alignment": top_issues[0].get("best_practice_alignment", {}),
+                },
+                {
                     "name": "business impact context",
                     "status": context_check["status"],
                     "notes": f"Business-impact context completeness: {context_check['score']:.0%}. Missing: {', '.join(gap['field'] for gap in context_check['missing_fields']) or 'none'}.",
@@ -1372,6 +1503,7 @@ def build_user_message(site_id: str, result: dict[str, Any], payload: dict[str, 
             f"- Type: `{top_action.get('type')}`",
             f"- Target: `{top_action.get('target')}`",
             f"- Why: {top_action.get('expected_impact')}",
+            f"- Best-practice lane: `{(top_action.get('best_practice_alignment') or {}).get('primary_area_label', 'not mapped')}`",
             f"- Requires approval: {'yes' if top_action.get('requires_approval') else 'no'}",
         ])
         deep_dive = top_action.get("deep_dive") or {}

--- a/openclaw/shared/recommendation-quality.md
+++ b/openclaw/shared/recommendation-quality.md
@@ -6,6 +6,8 @@ The OpenClaw SEO operator should behave like an analyst, not an alert router.
 
 Prefer recommendations with clear expected upside, enough evidence, and an obvious next lever. Avoid ranking noisy metric movement above actionable opportunities just because the percentage change is large.
 
+Use `seo/shared/seo-best-practices.md` as the durable reference. Every top recommendation should map to exactly one primary MECE best-practice lane so the operator knows whether the right next action is eligibility/indexing, intent targeting, content usefulness, SERP packaging, technical UX, authority, local presence, or measurement.
+
 ## Judgment levers
 
 Each recommendation should expose the inputs that drove ranking:
@@ -18,6 +20,7 @@ Each recommendation should expose the inputs that drove ranking:
 - `business_context_goal_score` — whether the opportunity matches the site-specific business goal, e.g. local qualified outcomes over national informational traffic
 - `url_quality_score` — whether the URL is canonical/actionable or a tracking/parameter variant
 - `learned_multiplier` — site-local prior from previous outcomes
+- `best_practice_alignment` — the primary SEO best-practice lane, source references, and why the action belongs there
 
 These are not hard approval rules. They are decision levers for the operator and the human reviewer.
 
@@ -38,6 +41,7 @@ These are not hard approval rules. They are decision levers for the operator and
 - Let high-impression, high-position, low-CTR opportunities outrank low-volume noisy regressions only when business intent, site-specific business context, and actionability are also strong.
 - For informational price queries, classify the action as snippet/content packaging or query-intent mapping unless a SERP diagnosis proves metadata is the main lever.
 - Explain why the top action is actionable and what would make it unsafe or low-confidence.
+- Attach `best_practice_alignment` to proposals and action-plan entries. If an action cannot be mapped to one primary best-practice lane, downgrade it to investigation/manual review.
 - Before proposing an edit for CTR/snippet/content opportunities, automatically run a deep-dive diagnostic: SERP snapshot, current title/meta/H1, above-the-fold content packaging, CTA/price-answer check, and zero-click risk classification.
 - If business context deprioritizes a traffic class, reframe the recommendation instead of chasing raw clicks. Example: for a local service business that only values local qualified outcomes, broad national cost-query CTR should become a local intent ownership / consolidation proposal, not a national blog CTR optimization.
 - If business-impact context is incomplete, create an explicit `business_context_request` queue item and surface the questions in the runner result instead of burying them in verification warnings. Missing business context blocks approval/editing, but should not block the diagnostic deep dive.

--- a/openclaw/skills/toprank-weekly-review/SKILL.md
+++ b/openclaw/skills/toprank-weekly-review/SKILL.md
@@ -10,16 +10,17 @@ metadata: { "openclaw": { "emoji": "📈", "homepage": "https://github.com/nowor
 2. Read `{baseDir}/../../shared/artifact-contract.md`.
 3. Read `{baseDir}/../../shared/policy.md`.
 4. Read `{baseDir}/../../shared/recommendation-quality.md`.
-5. Resolve the target `site_id`; if no site was specified and multiple sites are active, run portfolio review first or ask the user which site to review.
-6. Read and follow the canonical Toprank skill at `{baseDir}/../../../seo/seo-analysis/SKILL.md`.
-7. Prefer the automated runner:
+5. Read `{baseDir}/../../../seo/shared/seo-best-practices.md` and use its MECE lanes to explain why the top action is the right kind of SEO work.
+6. Resolve the target `site_id`; if no site was specified and multiple sites are active, run portfolio review first or ask the user which site to review.
+7. Read and follow the canonical Toprank skill at `{baseDir}/../../../seo/seo-analysis/SKILL.md`.
+8. Prefer the automated runner:
    - `python3 {baseDir}/../../bin/weekly_review.py <site_id-or-url>`
    - add `--gsc-property` if the site profile does not already contain one
    - add `--analysis-file` when testing against a saved GSC analysis JSON fixture
-8. The runner will generate and persist the review artifacts automatically, including automatic deep-dive diagnostics for the top CTR/snippet/content opportunity when applicable.
-9. Verify that the run wrote `audit.json`, `action-plan.json`, and `verification.json`, refreshed `latest-state.json`, and created queue items. The top proposal should include `deep_dive` with SERP, current snippet, above-the-fold, and zero-click checks before approval.
-10. If runner stdout includes `user_message`, use it as the user-facing summary. If it includes `business_context_request`, explicitly ask those questions in chat; do not just report artifact paths or say business context is incomplete.
-11. If the next action requires editing a site repo, CMS, publishing content, or opening a PR, stop and ask for approval before doing it. Missing business context blocks approval/editing, not investigation.
+9. The runner will generate and persist the review artifacts automatically, including automatic deep-dive diagnostics for the top CTR/snippet/content opportunity when applicable.
+10. Verify that the run wrote `audit.json`, `action-plan.json`, and `verification.json`, refreshed `latest-state.json`, and created queue items. The top proposal should include `best_practice_alignment` plus `deep_dive` with SERP, current snippet, above-the-fold, and zero-click checks before approval.
+11. If runner stdout includes `user_message`, use it as the user-facing summary. If it includes `business_context_request`, explicitly ask those questions in chat; do not just report artifact paths or say business context is incomplete.
+12. If the next action requires editing a site repo, CMS, publishing content, or opening a PR, stop and ask for approval before doing it. Missing business context blocks approval/editing, not investigation.
 
 ## Wrapper job
 

--- a/openclaw/tests/test_weekly_review_scoring.py
+++ b/openclaw/tests/test_weekly_review_scoring.py
@@ -479,6 +479,84 @@ class WeeklyReviewScoringTest(unittest.TestCase):
         self.assertTrue(any(gap["field"] == "service_value_weights" for gap in context_request["business_context_gaps"]))
         self.assertTrue(context_request["business_context_questions"])
 
+    def test_action_proposal_includes_best_practice_alignment(self) -> None:
+        analysis = self.base_analysis()
+        analysis["ctr_gaps_by_page"] = [
+            {
+                "query": "roof repair cost",
+                "page": "https://www.example.com/blog/roof-repair-cost",
+                "clicks": 2,
+                "impressions": 1681,
+                "ctr": 0.12,
+                "position": 2.8,
+            }
+        ]
+
+        payload = weekly_review.build_payload("example.com", analysis, {"priors": {}}, None)
+        proposal = next(item for item in payload["queue_items"] if item["type"] == "action_proposal")
+        action = payload["action_plan"]["actions"][0]
+        check = next(item for item in payload["verification"]["checks"] if item["name"] == "best practice alignment")
+
+        self.assertEqual(check["status"], "pass")
+        self.assertEqual(proposal["best_practice_alignment"]["reference"], "seo/shared/seo-best-practices.md")
+        self.assertEqual(action["best_practice_alignment"]["primary_area"], "on_page_relevance_serp_packaging")
+        self.assertTrue(proposal["best_practice_alignment"]["resources"])
+
+    def test_all_current_action_types_have_best_practice_mapping(self) -> None:
+        expected_action_types = {
+            "canonical_or_tracking_investigation",
+            "query_intent_mapping",
+            "local_intent_ownership",
+            "content_refresh",
+            "page_improvement",
+            "meta_tags",
+            "snippet_content_packaging",
+            "internal_links",
+            "manual_review",
+        }
+
+        self.assertEqual(set(weekly_review.ACTION_BEST_PRACTICE_AREAS), expected_action_types)
+        for action_type, area in weekly_review.ACTION_BEST_PRACTICE_AREAS.items():
+            with self.subTest(action_type=action_type):
+                self.assertIn(area, weekly_review.SEO_BEST_PRACTICE_AREAS)
+                alignment = weekly_review.best_practice_alignment_for_issue({"recommended_action_type": action_type})
+                self.assertEqual(alignment["primary_area"], area)
+                self.assertNotEqual(alignment["primary_area"], "unmapped")
+
+    def test_unknown_action_type_warns_as_unmapped(self) -> None:
+        alignment = weekly_review.best_practice_alignment_for_issue({"recommended_action_type": "core_web_vitals"})
+
+        self.assertEqual(alignment["primary_area"], "unmapped")
+        self.assertEqual(alignment["primary_area_label"], "Unmapped SEO action type")
+        self.assertTrue(any("core_web_vitals" in note for note in alignment["notes"]))
+
+        analysis = self.base_analysis()
+        original = weekly_review.derive_candidate_issues
+        weekly_review.derive_candidate_issues = lambda _analysis: [
+            {
+                "title": "Future action",
+                "severity": "info",
+                "confidence": 0.5,
+                "evidence": ["synthetic"],
+                "recommended_action_type": "core_web_vitals",
+                "base_priority": 0.5,
+                "priority_score": 0.5,
+                "operator_judgment_notes": [],
+                "score_components": {},
+                "raw_target": None,
+                "canonical_target": None,
+            }
+        ]
+        try:
+            payload = weekly_review.build_payload("example.com", analysis, {"priors": {}}, None)
+        finally:
+            weekly_review.derive_candidate_issues = original
+
+        check = next(item for item in payload["verification"]["checks"] if item["name"] == "best practice alignment")
+        action = payload["action_plan"]["actions"][0]
+        self.assertEqual(check["status"], "warning")
+        self.assertEqual(action["best_practice_alignment"]["primary_area"], "unmapped")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/seo/shared/seo-best-practices.md
+++ b/seo/shared/seo-best-practices.md
@@ -1,0 +1,206 @@
+# SEO Best Practices Reference
+
+This is the shared reference for Toprank SEO operators. Use it to keep recommendations grounded in durable SEO principles rather than one-off heuristics.
+
+## Primary resources
+
+1. **Google Search Central — SEO Starter Guide**  
+   https://developers.google.com/search/docs/fundamentals/seo-starter-guide  
+   Best for: crawl/index basics, site organization, descriptive URLs, titles, snippets, links, images, and measuring impact over weeks/months.
+
+2. **Google Search Essentials**  
+   https://developers.google.com/search/docs/essentials  
+   Best for: eligibility, technical requirements, spam boundaries, helpful content, crawlable links, prominent keyword placement, and Search appearance basics.
+
+3. **Google — Creating Helpful, Reliable, People-First Content**  
+   https://developers.google.com/search/docs/fundamentals/creating-helpful-content  
+   Best for: content quality, originality, usefulness, first-hand expertise, E-E-A-T, and avoiding search-engine-first content.
+
+4. **Google — Page Experience**  
+   https://developers.google.com/search/docs/appearance/page-experience  
+   Best for: Core Web Vitals, HTTPS, mobile usability, intrusive interstitials, main-content clarity, and overall UX.
+
+5. **Google — Structured Data Introduction**  
+   https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data  
+   Best for: JSON-LD, rich results, validation, and giving explicit machine-readable clues about page meaning.
+
+6. **Google Business Profile Help — Local Ranking**  
+   https://support.google.com/business/answer/7091  
+   Best for: local ranking factors: relevance, distance, prominence; complete business info; reviews; photos/videos; hours; categories.
+
+7. **Ahrefs — Beginner’s Guide to SEO**  
+   https://ahrefs.com/seo  
+   Best for: practical learning path across keyword research, content, on-page SEO, link building, technical SEO, local SEO, and AI search.
+
+8. **Moz — Beginner’s Guide to SEO**  
+   https://moz.com/beginners-guide-to-seo  
+   Best for: SEO hierarchy: crawl accessibility → content → keyword optimization → UX → links/citations → CTR → schema/snippets.
+
+## MECE improvement framework
+
+Every SEO opportunity should map to exactly one primary improvement lane. A recommendation can mention secondary lanes, but the operator should rank and explain it through one primary lane to avoid muddled actions.
+
+### 1. Search eligibility & indexability
+
+**Goal:** Google can discover, crawl, render, canonicalize, and index the right URLs.
+
+Includes:
+- robots directives, noindex, canonical tags, redirects
+- sitemap and internal discoverability
+- crawlable links
+- duplicate URL consolidation
+- JavaScript/rendering visibility
+
+Typical actions:
+- fix blocked/uncrawlable pages
+- consolidate duplicate URLs
+- repair canonical/redirect mistakes
+- submit or refresh sitemap
+
+Do not confuse with: content quality. If Google cannot reliably access the page, content optimization is premature.
+
+### 2. Demand & intent targeting
+
+**Goal:** Choose the search demand worth winning, based on business value and searcher intent.
+
+Includes:
+- keyword/query research
+- brand vs non-brand split
+- local/commercial/research/informational intent classification
+- priority services, locations, customers, and conversion events
+- query-to-page ownership
+
+Typical actions:
+- identify high-value query clusters
+- map queries to transactional vs supporting pages
+- demote low-value national informational traffic when local bookings are the goal
+- choose the one page that should own each intent
+
+Do not confuse with: SERP packaging. First decide whether the query is worth winning and which page should win it.
+
+### 3. Content usefulness & trust
+
+**Goal:** The page gives users a satisfying answer and demonstrates credible experience/expertise.
+
+Includes:
+- original useful information, not commodity rewrites
+- completeness relative to the SERP
+- first-hand proof, examples, reviews, local details, pricing context
+- author/site trust signals where relevant
+- freshness only when substance changes
+
+Typical actions:
+- add missing information users need to decide
+- replace generic copy with specific proof
+- add comparison, pricing, process, FAQs, or service-area details when useful
+- prune or merge thin/duplicative content
+
+Do not confuse with: metadata. If the page itself does not satisfy intent, title tweaks are lipstick.
+
+### 4. On-page relevance & SERP packaging
+
+**Goal:** Searchers and search engines can quickly understand why this page is the right result.
+
+Includes:
+- title, H1, meta description, headings
+- above-the-fold answer clarity
+- internal anchor text
+- image alt text where useful
+- structured data/rich-result eligibility
+- snippet and CTR diagnostics
+
+Typical actions:
+- rewrite title/meta/H1 for the actual query intent
+- add fast answer blocks or CTAs above the fold
+- improve internal anchors to the target page
+- add valid JSON-LD only when content is visible and eligible
+
+Do not confuse with: demand selection. Metadata improvements matter only after the target query/page pairing is correct.
+
+### 5. Technical UX & page experience
+
+**Goal:** The page is fast, secure, mobile-friendly, and usable enough that experience does not suppress performance.
+
+Includes:
+- Core Web Vitals
+- HTTPS
+- mobile usability/responsive layout
+- intrusive interstitials/dialogs
+- ad or layout clutter
+- main-content clarity
+
+Typical actions:
+- improve LCP/INP/CLS bottlenecks
+- remove intrusive blockers
+- fix mobile layout issues
+- make primary content and CTA obvious
+
+Do not confuse with: ranking magic. Perfect Lighthouse scores do not compensate for weak intent/content.
+
+### 6. Authority & distribution
+
+**Goal:** Earn enough off-page and internal authority for competitive terms.
+
+Includes:
+- backlinks and mentions
+- citations/directories where relevant
+- internal link equity
+- promotion in relevant communities
+- reputation signals that users and search engines can corroborate
+
+Typical actions:
+- build internal links from relevant high-authority pages
+- earn local citations or editorial mentions
+- promote genuinely useful assets
+- fix orphaned important pages
+
+Do not confuse with: spammy link building. Authority work should be reputation-building, not manipulation.
+
+### 7. Local presence & reputation
+
+**Goal:** For local businesses, win relevant map/local results through complete, trusted, locally specific signals.
+
+Includes:
+- Google Business Profile completeness and categories
+- NAP, hours, services, photos/videos
+- reviews, ratings, and owner responses
+- service areas and location pages
+- local proof points and prominence
+
+Typical actions:
+- complete/update GBP fields
+- improve review acquisition/response workflows
+- add local proof to service/location pages
+- align website pages with priority locations/services
+
+Do not confuse with: generic organic SEO. Local search adds relevance, distance, and prominence constraints.
+
+### 8. Measurement, prioritization & experimentation
+
+**Goal:** Improve business outcomes with evidence, not vanity traffic.
+
+Includes:
+- GSC/GA4/CRM conversion measurement
+- baselines and holdout/after windows
+- normalized metrics: CTR, conversion rate, clicks per impression, leads per organic session
+- confidence/sample size
+- follow-up checks and learned priors
+- approval guardrails
+
+Typical actions:
+- define success metric before editing
+- create proposal + baseline + follow-up window
+- separate regression investigation from publishable edits
+- update learned priors after results mature
+
+Do not confuse with: dashboards. Measurement exists to choose and validate actions.
+
+## Operator checklist before proposing an SEO edit
+
+1. **Eligibility:** Can Google access and understand the page? If no, fix lane 1 first.
+2. **Intent:** Is this query/page worth winning for the business? If unclear, ask for business context or map query ownership.
+3. **Page fit:** Does the target page actually satisfy the intent? If no, improve/merge/reroute before metadata changes.
+4. **SERP fit:** Does the live SERP suggest CTR/snippet packaging, zero-click risk, local pack pressure, or a different content format?
+5. **Business value:** What conversion or qualified outcome should improve?
+6. **Risk:** Would the change affect production content, redirects, canonicals, CMS, PRs, or metadata? If yes, require approval.
+7. **Measurement:** What baseline, success threshold, guardrail, and follow-up date will prove whether it worked?


### PR DESCRIPTION
## Summary
- Add a durable MECE SEO best-practices reference for Toprank operators.
- Attach `best_practice_alignment` to weekly review issues, action-plan entries, queue proposals, verification checks, and user-facing summaries.
- Warn explicitly when a future `recommended_action_type` is unmapped instead of silently assigning it to measurement.
- Update weekly-review/recommendation-quality docs and add mapping coverage tests.

## Validation
- `python3 -m unittest openclaw.tests.test_weekly_review_scoring` → 20 passed
- `python3 -m compileall -q openclaw/bin/weekly_review.py`
- `python3 -m pytest -q openclaw/tests test/openclaw test/unit/test_analyze_gsc.py test/unit/test_url_inspection.py` → 184 passed, 9 subtests passed
- Full repo privacy `git grep` for customer-specific/secrets terms passed
- Native `codex review --uncommitted` found no actionable correctness issues; sandbox-only temp-dir warning did not reproduce locally

## Notes
- This is additive/backward-compatible schema-wise.
- Runtime copy is already current because `/Users/tongchen/.openclaw/bin/weekly_review.py` is hardlinked to the repo file; shared docs resolve via the existing symlinked `seo/` tree.
