### PR TITLE
fix: keep service pages prioritized for branded CTR gaps

### DIFF
--- a/openclaw/bin/weekly_review.py
+++ b/openclaw/bin/weekly_review.py
@@ -412,6 +412,22 @@ def is_branded_query(query: str | None, brand_terms: list[str] | None) -> bool:
     return any(term and term.lower() in q for term in brand_terms)
 
 
+SERVICE_PAGE_PATTERNS = re.compile(r"/(?:locations?|services?|pricing|booking|book|reserve|contact|about|faq|gallery|rates?|review|team|careers?|apply|shop|products?|dogs?-(?:boarding?|daycare|sitting?|grooming|training)|pet-(?:boarding?|daycare|sitting?|grooming|training))")
+
+
+def is_service_page(url: str | None) -> bool:
+    """True if the URL looks like a service/business page, not a blog or content article."""
+    if not url:
+        return False
+    path = urlparse(url).path.rstrip("/") or "/"
+    if re.search(r"/(?:blogs?|blog|news|articles?|posts?|journal|category|tag/|author/)", path):
+        return False
+    if bool(SERVICE_PAGE_PATTERNS.search(path)):
+        return True
+    # Short paths with no subdirectory are likely service pages (e.g. /dog-boarding, /)
+    return path.count("/") <= 2
+
+
 def goal_alignment_for_query(query: str | None, brand_terms: list[str] | None) -> tuple[float, list[str]]:
     if is_branded_query(query, brand_terms):
         return 0.35, ["branded/navigational query; lower priority for non-brand growth"]
@@ -576,7 +592,14 @@ def ctr_gap_issue(gap: dict[str, Any], brand_terms: list[str] | None = None) -> 
             "recommend SERP + snippet + above-the-fold content diagnosis before editing",
         ]
     url_quality = float(url_context(raw_target)["url_quality_score"])
-    goal_alignment_score, goal_notes = goal_alignment_for_query(query, brand_terms)
+    # For service pages, goal_alignment considers the page's role, not just the top
+    # underperforming query. A boarding page at position 1.2 with 943 impressions is
+    # inherently valuable — the branded query is just what's currently underperforming.
+    if is_service_page(raw_target) and is_branded_query(query, brand_terms):
+        goal_alignment_score = 1.0
+        goal_notes = ["service page; goal alignment based on page role, not gap query"]
+    else:
+        goal_alignment_score, goal_notes = goal_alignment_for_query(query, brand_terms)
     score = impact_score * confidence * goal_alignment_score * actionability_score * url_quality * business_intent_score
     evidence = [
         f"{impressions:g} impressions with CTR {ctr}%.",

--- a/openclaw/tests/test_weekly_review_scoring.py
+++ b/openclaw/tests/test_weekly_review_scoring.py
@@ -122,6 +122,38 @@ class WeeklyReviewScoringTest(unittest.TestCase):
         self.assertEqual(issue["score_components"]["business_intent_score"], 1.0)
         self.assertFalse(any("metadata alone is unproven" in note for note in issue["operator_judgment_notes"]))
 
+    def test_branded_gap_on_service_page_keeps_page_aligned(self) -> None:
+        issue = weekly_review.ctr_gap_issue(
+            {
+                "query": "example boarding",
+                "page": "https://www.example.com/dog-boarding",
+                "clicks": 91,
+                "impressions": 943,
+                "ctr": 9.65,
+                "position": 1.2,
+            },
+            ["example"],
+        )
+
+        self.assertEqual(issue["score_components"]["goal_alignment_score"], 1.0)
+        self.assertTrue(any("service page" in note for note in issue["operator_judgment_notes"]))
+
+    def test_branded_gap_on_blog_stays_lower_priority(self) -> None:
+        issue = weekly_review.ctr_gap_issue(
+            {
+                "query": "example boarding",
+                "page": "https://www.example.com/blog/dog-boarding-guide",
+                "clicks": 91,
+                "impressions": 943,
+                "ctr": 9.65,
+                "position": 1.2,
+            },
+            ["example"],
+        )
+
+        self.assertLess(issue["score_components"]["goal_alignment_score"], 1.0)
+        self.assertTrue(any("branded/navigational" in note for note in issue["operator_judgment_notes"]))
+
     def test_informational_ctr_gap_is_not_metadata_only(self) -> None:
         issue = weekly_review.ctr_gap_issue(
             {


### PR DESCRIPTION
## Summary
- Treat branded CTR gaps on service/business pages as page-aligned instead of low-priority navigational noise
- Keep blog/content URLs under the existing lower-priority branded-query handling
- Add scoring tests for both service-page and blog cases

## Tests
- python3 -m pytest openclaw/tests/test_weekly_review_scoring.py test/openclaw/test_openclaw_mvp.py -q