### PR TITLE
Add Linux folder picker support using zenity/kdialog

### DIFF
--- a/notfair-cmo/src/server/fs/pick-folder.ts
+++ b/notfair-cmo/src/server/fs/pick-folder.ts
@@ -35,7 +35,10 @@ export async function pickFolder(opts: {
   if (p === "darwin") {
     return pickFolderMac(opts);
   }
-  // TODO: linux (zenity / kdialog), win32 (PowerShell FolderBrowserDialog).
+  if (p === "linux") {
+    return pickFolderLinux(opts);
+  }
+  // TODO: win32 (PowerShell FolderBrowserDialog).
   return { ok: false, kind: "unsupported", platform: p };
 }
 
@@ -107,4 +110,93 @@ async function pickFolderMac(opts: {
   // strip it for consistency with how users typically write paths.
   const normalized = out.replace(/\/+$/, "");
   return { ok: true, path: normalized };
+}
+
+async function pickFolderLinux(opts: {
+  prompt?: string;
+  defaultLocation?: string;
+}): Promise<PickFolderResult> {
+  const prompt = opts.prompt ?? "Select a folder";
+
+  // Try zenity first (GTK-based, most common on GNOME/Ubuntu/Fedora),
+  // fall back to kdialog (KDE/Plasma).
+  const zenityArgs = [
+    "--file-selection",
+    "--directory",
+    `--title=${prompt}`,
+  ];
+  if (opts.defaultLocation) {
+    zenityArgs.push(`--filename=${opts.defaultLocation}/`);
+  }
+
+  const zenityResult = await execDialog("zenity", zenityArgs);
+  if (zenityResult !== null) {
+    return zenityResult;
+  }
+
+  // zenity not available, try kdialog
+  const kdialogArgs = [
+    "--getexistingdirectory",
+    opts.defaultLocation ?? "",
+    "--title",
+    prompt,
+  ];
+
+  const kdialogResult = await execDialog("kdialog", kdialogArgs);
+  if (kdialogResult !== null) {
+    return kdialogResult;
+  }
+
+  // Neither zenity nor kdialog available
+  return {
+    ok: false,
+    kind: "error",
+    message:
+      "No supported dialog tool found. Install zenity (GTK) or kdialog (KDE) for folder picker support.",
+  };
+}
+
+/**
+ * Execute a dialog command and return the result, or null if the command
+ * is not found (ENOENT), indicating we should try the next fallback.
+ */
+async function execDialog(
+  cmd: string,
+  args: string[],
+): Promise<PickFolderResult | null> {
+  return new Promise((resolve) => {
+    execFile(
+      cmd,
+      args,
+      { timeout: DIALOG_TIMEOUT_MS },
+      (err, stdout, stderr) => {
+        if (err) {
+          // ENOENT means the command doesn't exist — try next fallback
+          if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            resolve(null);
+            return;
+          }
+          // Exit code 1 in zenity/kdialog means user cancelled
+          if ("code" in err && (err as { code: number }).code === 1) {
+            resolve({ ok: false, kind: "cancelled" });
+            return;
+          }
+          resolve({
+            ok: false,
+            kind: "error",
+            message: stderr.trim() || err.message,
+          });
+          return;
+        }
+        const out = stdout.trim();
+        if (!out) {
+          resolve({ ok: false, kind: "cancelled" });
+          return;
+        }
+        // Normalize: strip trailing slash for consistency
+        const normalized = out.replace(/\/+$/, "");
+        resolve({ ok: true, path: normalized });
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Implements the Linux folder picker that was marked as TODO, enabling the 
Browse button to work on Linux desktops.

## Implementation

- **zenity** (GTK-based) as primary — most common on GNOME/Ubuntu/Fedora
- **kdialog** (KDE/Plasma) as fallback — for KDE users
- Returns clear error message if neither tool is available
- Falls back gracefully: UI can show text input when `kind: "error"` is returned

## Details

- Uses ENOENT detection to distinguish "not installed" from real errors
- Handles user cancellation (exit code 1) correctly for both tools
- Respects the same `DIALOG_TIMEOUT_MS` (5 min) as the macOS implementation
- Normalizes output (strips trailing slash) for consistency with macOS behavior
- Extracted shared `execDialog()` helper to avoid duplication between zenity/kdialog paths

## Addresses

TODO in `pick-folder.ts`:
> "linux (zenity / kdialog)"

## Type of change

- [x] New feature
