### PR TITLE
feat(notfair-cmo): add Workspace browser card to Settings

### DIFF
--- a/notfair-cmo/src/app/(app)/[project]/settings/page.tsx
+++ b/notfair-cmo/src/app/(app)/[project]/settings/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { getProject } from "@/server/db/projects";
 import { DangerZone } from "@/components/danger-zone";
 import { ProjectRenameCard } from "@/components/project-rename-card";
+import { WorkspaceBrowserCard } from "@/components/workspace-browser-card";
 
 export default async function SettingsPage({
   params,
@@ -58,6 +59,13 @@ export default async function SettingsPage({
             </dd>
           </dl>
         </div>
+      </section>
+
+      <section>
+        <h2 className="ns-h2">
+          <span>Workspace browser</span>
+        </h2>
+        <WorkspaceBrowserCard projectSlug={project.slug} />
       </section>
 
       <section>

--- a/notfair-cmo/src/components/workspace-browser-card.test.tsx
+++ b/notfair-cmo/src/components/workspace-browser-card.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { WorkspaceBrowserCard } from "./workspace-browser-card";
+
+// sonner.toast emits real DOM in jsdom; stub so we can assert on call args.
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const value = handler(url, init);
+    return new Response(JSON.stringify(value), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.fetch = originalFetch;
+});
+
+describe("WorkspaceBrowserCard", () => {
+  it("renders 'Not running' state on initial load when no session is active", async () => {
+    mockFetch(() => ({
+      status: { running: false, cdpPort: 19042, userDataDir: "/tmp/profile" },
+      tabs: [],
+    }));
+
+    render(<WorkspaceBrowserCard projectSlug="acme" />);
+
+    await waitFor(() => expect(screen.getByText(/Not running/)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /^Launch$/ })).toBeInTheDocument();
+    expect(screen.getByText(/Profile dir:/)).toBeInTheDocument();
+  });
+
+  it("shows running state, sign-in buttons, and open tabs when session is up", async () => {
+    mockFetch(() => ({
+      status: {
+        running: true,
+        cdpPort: 19042,
+        userDataDir: "/tmp/profile",
+        uptimeMs: 32_000,
+      },
+      tabs: [
+        { id: "greg", url: "https://greg.example/", title: "Greg" },
+        { id: "tina", url: "https://tina.example/", title: "Tina" },
+      ],
+    }));
+
+    render(<WorkspaceBrowserCard projectSlug="acme" />);
+
+    await waitFor(() => expect(screen.getByText(/Running on port 19042/)).toBeInTheDocument());
+    expect(screen.getByText(/32s uptime/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open Google/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open Meta/ })).toBeInTheDocument();
+    expect(screen.getByText("greg")).toBeInTheDocument();
+    expect(screen.getByText("Tina")).toBeInTheDocument();
+  });
+
+  it("POSTs to /api/browser/launch with headless=false when Launch is clicked", async () => {
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/status")) {
+        return new Response(
+          JSON.stringify({
+            status: { running: false, cdpPort: 19042, userDataDir: "/tmp/profile" },
+            tabs: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/launch")) {
+        return new Response(JSON.stringify({ status: { running: true } }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    render(<WorkspaceBrowserCard projectSlug="acme" />);
+    await waitFor(() => screen.getByRole("button", { name: /^Launch$/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Launch$/ }));
+
+    await waitFor(() => {
+      const launchCall = fetchSpy.mock.calls.find(([u]) => String(u).includes("/launch"));
+      expect(launchCall).toBeDefined();
+      const body = JSON.parse((launchCall![1] as RequestInit).body as string);
+      expect(body).toEqual({ project_slug: "acme", signin_url: undefined, headless: false });
+    });
+  });
+
+  it("POSTs to /api/browser/shutdown when Stop is clicked", async () => {
+    let runningState = true;
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/status")) {
+        return new Response(
+          JSON.stringify({
+            status: { running: runningState, cdpPort: 19042, userDataDir: "/tmp/profile" },
+            tabs: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/shutdown")) {
+        runningState = false;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    render(<WorkspaceBrowserCard projectSlug="acme" />);
+    await waitFor(() => screen.getByRole("button", { name: /^Stop$/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Stop$/ }));
+
+    await waitFor(() => {
+      const shutdownCall = fetchSpy.mock.calls.find(([u]) => String(u).includes("/shutdown"));
+      expect(shutdownCall).toBeDefined();
+    });
+  });
+
+  it("POSTs signin_url when a sign-in target button is clicked", async () => {
+    const fetchSpy = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.includes("/status")) {
+        return new Response(
+          JSON.stringify({
+            status: {
+              running: true,
+              cdpPort: 19042,
+              userDataDir: "/tmp/profile",
+              uptimeMs: 1_000,
+            },
+            tabs: [],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ status: { running: true } }), { status: 200 });
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    render(<WorkspaceBrowserCard projectSlug="acme" />);
+    await waitFor(() => screen.getByRole("button", { name: /Open Google/ }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Open Google/ }));
+
+    await waitFor(() => {
+      const launchCall = fetchSpy.mock.calls.find(([u]) => String(u).includes("/launch"));
+      expect(launchCall).toBeDefined();
+      const body = JSON.parse(launchCall![1]!.body as string);
+      expect(body.signin_url).toBe("https://accounts.google.com/");
+    });
+  });
+});

--- a/notfair-cmo/src/components/workspace-browser-card.tsx
+++ b/notfair-cmo/src/components/workspace-browser-card.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+type Status = {
+  running: boolean;
+  cdpPort: number;
+  userDataDir: string;
+  uptimeMs?: number;
+};
+
+type Tab = { id: string; url: string; title: string };
+
+const SIGNIN_TARGETS: Array<{ label: string; url: string }> = [
+  { label: "Google", url: "https://accounts.google.com/" },
+  { label: "Meta / Facebook", url: "https://www.facebook.com/login/" },
+  { label: "Search Console", url: "https://search.google.com/search-console" },
+];
+
+export function WorkspaceBrowserCard({ projectSlug }: { projectSlug: string }) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [tabs, setTabs] = useState<Tab[]>([]);
+  const [pending, setPending] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/browser/status?project_slug=${encodeURIComponent(projectSlug)}`,
+        { cache: "no-store" },
+      );
+      const body = await res.json();
+      setStatus(body.status);
+      setTabs(body.tabs ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectSlug]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function launch(signinUrl?: string) {
+    setPending(true);
+    try {
+      const res = await fetch("/api/browser/launch", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          project_slug: projectSlug,
+          signin_url: signinUrl,
+          headless: false,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Launch failed");
+      toast.success(
+        signinUrl
+          ? `Opened ${new URL(signinUrl).hostname} — sign in, then come back.`
+          : "Workspace browser is running.",
+      );
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function shutdown() {
+    setPending(true);
+    try {
+      const res = await fetch("/api/browser/shutdown", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ project_slug: projectSlug }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Shutdown failed");
+      toast.success("Workspace browser stopped. Cookies persist for next launch.");
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="ns-card">
+      <div className="space-y-4 p-[18px]">
+        <div>
+          <h3 className="text-[14.5px] font-semibold tracking-tight text-[hsl(var(--notfair-ink))]">
+            Workspace browser
+          </h3>
+          <p className="mt-1 text-[12.5px] leading-snug text-[hsl(var(--notfair-ink-4))]">
+            Agents share a single Chrome instance with persistent cookies.
+            Sign in once here (Google, Meta, Search Console, …) and every
+            agent inherits the session. Each agent gets its own labeled tab,
+            so they don&apos;t race.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span
+            className={
+              "inline-flex items-center gap-1.5 text-[12.5px] " +
+              (status?.running
+                ? "text-[hsl(var(--notfair-ink-2))]"
+                : "text-[hsl(var(--notfair-ink-4))]")
+            }
+          >
+            <span
+              className={
+                "h-1.5 w-1.5 rounded-full " +
+                (status?.running ? "bg-emerald-500" : "bg-[hsl(var(--notfair-ink-5))]")
+              }
+            />
+            {loading
+              ? "Checking…"
+              : status?.running
+                ? `Running on port ${status.cdpPort}` +
+                  (status.uptimeMs ? ` · ${Math.round(status.uptimeMs / 1000)}s uptime` : "")
+                : "Not running"}
+          </span>
+
+          <div className="ml-auto flex gap-2">
+            {status?.running ? (
+              <Button size="sm" variant="ghost" disabled={pending} onClick={shutdown}>
+                {pending && <Loader2 className="h-3 w-3 animate-spin" />}
+                Stop
+              </Button>
+            ) : (
+              <Button size="sm" disabled={pending} onClick={() => launch()}>
+                {pending && <Loader2 className="h-3 w-3 animate-spin" />}
+                Launch
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {status?.running && (
+          <div className="space-y-3">
+            <div>
+              <div className="text-[12px] font-medium uppercase tracking-wide text-[hsl(var(--notfair-ink-4))]">
+                Sign in to a service
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {SIGNIN_TARGETS.map((target) => (
+                  <Button
+                    key={target.url}
+                    size="sm"
+                    variant="outline"
+                    disabled={pending}
+                    onClick={() => launch(target.url)}
+                  >
+                    Open {target.label}
+                  </Button>
+                ))}
+              </div>
+              <p className="mt-2 text-[12px] text-[hsl(var(--notfair-ink-4))]">
+                Clicking opens (or reuses) a tab labelled <code>signin</code>.
+                Complete the login in the Chrome window — cookies persist
+                automatically in this workspace&apos;s profile directory.
+              </p>
+            </div>
+
+            {tabs.length > 0 && (
+              <div>
+                <div className="text-[12px] font-medium uppercase tracking-wide text-[hsl(var(--notfair-ink-4))]">
+                  Open tabs ({tabs.length})
+                </div>
+                <ul className="mt-2 space-y-1">
+                  {tabs.map((tab) => (
+                    <li
+                      key={tab.id}
+                      className="flex items-center gap-2 text-[12.5px] text-[hsl(var(--notfair-ink-2))]"
+                    >
+                      <span className="ns-tag-mono">{tab.id}</span>
+                      <span className="truncate" title={tab.url}>
+                        {tab.title || tab.url}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {status && !status.running && (
+          <p className="text-[11.5px] text-[hsl(var(--notfair-ink-4))]">
+            Profile dir: <code className="break-all">{status.userDataDir}</code>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Workspace browser** card to Settings (`/$\{project}/settings`) so users can manage the workspace Chrome from the UI rather than via the agent-facing MCP tools.

What the card does:
- **Live status** — running / not running, CDP port, uptime
- **Launch** — pops the workspace Chrome headed (so the user can interact)
- **Sign in to Google / Meta / Search Console** — opens (or reuses) a tab labelled `signin` pointing at the chosen account-management URL. Cookies persist in `~/.notfair-cmo/projects/<slug>/browser/user-data/` so every agent inherits the session.
- **Open tabs** — handle + title list
- **Stop** — graceful shutdown; cookies survive

## Why Settings, not the onboarding wizard

Considered both. Settings won for V1:
- Onboarding-flow.tsx is 1500 lines of carefully-tuned PKCE OAuth + agent provisioning logic. Adding a step risks breaking that flow for low return until we know what real users do.
- Browser sign-in (cookies for human-facing UIs like Search Console) is conceptually distinct from MCP OAuth (API-level), so blending them in onboarding would confuse the auth model rather than clarify it.
- Users who hit a login wall via an agent will be told to "open Settings → Workspace browser → Launch and sign in" — the agent prompt change in #83 already trains them to surface blockers.

Once we have real usage data, we can promote it into the wizard.

## Test plan

- [x] `pnpm test src/components/workspace-browser-card.test.tsx` — 5 pass (5 component interaction tests with mocked `fetch`)
- [x] `pnpm typecheck` — no new errors
- [x] Manual dev verification:
  - Settings page renders the card with "Not running" + correct profile dir
  - Clicking Launch hits `/api/browser/launch`, spawns Chrome with the exact `--user-data-dir` + `--remote-debugging-port=19081` flags we built
  - Card updates to "Running on port 19081 · 10s uptime"
  - Stop button hits `/api/browser/shutdown` and the Chrome process exits cleanly

## Stacking

Stacks on #82 (foundation) + #83 (agent guidance). Merge in order: 82 → 83 → 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)