### PR TITLE
fix(notfair-cmo): remove browser_shutdown from agent MCP surface

### DIFF
--- a/notfair-cmo/src/server/mcp-server/browser-tools.test.ts
+++ b/notfair-cmo/src/server/mcp-server/browser-tools.test.ts
@@ -15,7 +15,6 @@ vi.mock("@/server/browser/session", () => ({
     launchedAt: 1_000,
     uptimeMs: 5_000,
   })),
-  stopBrowser: vi.fn(async () => {}),
 }));
 
 vi.mock("@/server/browser/tabs", () => ({
@@ -74,7 +73,7 @@ afterEach(() => {
 // ── Registry shape ─────────────────────────────────────────────────────
 
 describe("BROWSER_TOOLS registry", () => {
-  it("exposes exactly the 12 expected tools (status, tabs, open, close, navigate, snapshot, click, type, press, scroll, back, shutdown)", () => {
+  it("exposes exactly the 11 expected tools (no shutdown — that's intentionally user-only)", () => {
     expect(BROWSER_TOOLS.map((t) => t.name).sort()).toEqual(
       [
         "browser_back",
@@ -84,13 +83,17 @@ describe("BROWSER_TOOLS registry", () => {
         "browser_open",
         "browser_press",
         "browser_scroll",
-        "browser_shutdown",
         "browser_snapshot",
         "browser_status",
         "browser_tabs",
         "browser_type",
       ].sort(),
     );
+  });
+
+  it("does NOT expose browser_shutdown to agents (multi-agent safety: any agent calling it would kill Chrome for the others)", () => {
+    const names = BROWSER_TOOLS.map((t) => t.name);
+    expect(names).not.toContain("browser_shutdown");
   });
 
   it("each tool ships a non-empty description and a zod inputSchema", () => {
@@ -347,7 +350,7 @@ describe("browser_scroll", () => {
   });
 });
 
-// ── browser_back / browser_shutdown ────────────────────────────────────
+// ── browser_back ───────────────────────────────────────────────────────
 
 describe("browser_back", () => {
   it("invokes actions.back", async () => {
@@ -357,13 +360,5 @@ describe("browser_back", () => {
     );
     expect(result.ok).toBe(true);
     expect(actions.back).toHaveBeenCalledOnce();
-  });
-});
-
-describe("browser_shutdown", () => {
-  it("calls stopBrowser and reports success", async () => {
-    const result = await tool("browser_shutdown").handler({ project_slug: "acme" }, {});
-    expect(result.ok).toBe(true);
-    expect(session.stopBrowser).toHaveBeenCalledWith("acme");
   });
 });

--- a/notfair-cmo/src/server/mcp-server/browser-tools.ts
+++ b/notfair-cmo/src/server/mcp-server/browser-tools.ts
@@ -19,7 +19,7 @@ import {
   type as actType,
   type SnapshotElement,
 } from "@/server/browser/actions";
-import { getOrLaunchBrowser, getSessionStatus, stopBrowser } from "@/server/browser/session";
+import { getOrLaunchBrowser, getSessionStatus } from "@/server/browser/session";
 import { closeTab, getTab, listTabs, openTab } from "@/server/browser/tabs";
 
 import type { ToolDefinition, ToolResult } from "./tools";
@@ -352,20 +352,12 @@ async function handleBrowserBack(input: unknown): Promise<ToolResult> {
   return result;
 }
 
-// ── browser_shutdown (admin) ───────────────────────────────────────────
-
-const browserShutdownInput = z.object({ project_slug: projectSlug });
-
-async function handleBrowserShutdown(input: unknown): Promise<ToolResult> {
-  const parsed = browserShutdownInput.safeParse(input);
-  if (!parsed.success) return invalid(parsed.error);
-  try {
-    await stopBrowser(parsed.data.project_slug);
-    return txt(`Workspace browser for "${parsed.data.project_slug}" stopped.`);
-  } catch (err) {
-    return fail(`browser_shutdown failed: ${safeMessage(err)}`);
-  }
-}
+// browser_shutdown is intentionally NOT exposed as an agent tool. With multiple
+// agents sharing one workspace Chrome, any agent calling shutdown would kill
+// the browser out from under the others mid-task. Browser lifecycle stays
+// owned by the user (Settings → Workspace browser → Stop) and by process exit
+// hooks. The /api/browser/shutdown route imports stopBrowser directly from
+// session.ts; agents do not get this primitive.
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -456,12 +448,5 @@ export const BROWSER_TOOLS: ToolDefinition[] = [
       "Navigate back one entry in the tab's history. No-ops cleanly on the first page (no error).",
     inputSchema: browserBackInput,
     handler: handleBrowserBack,
-  },
-  {
-    name: "browser_shutdown",
-    description:
-      "Stop the workspace browser. Use rarely — only when the user explicitly asks to close it. Cookies persist in the profile dir, so the next browser_open relaunches with the same session.",
-    inputSchema: browserShutdownInput,
-    handler: handleBrowserShutdown,
   },
 ];

--- a/notfair-cmo/src/server/skills/orchestration-skill.test.ts
+++ b/notfair-cmo/src/server/skills/orchestration-skill.test.ts
@@ -100,10 +100,15 @@ describe("ORCHESTRATION_SKILL", () => {
       "browser_press",
       "browser_scroll",
       "browser_back",
-      "browser_shutdown",
     ]) {
       expect(s).toContain(tool);
     }
+  });
+
+  it("tells agents they CANNOT stop the workspace browser (multi-agent safety)", () => {
+    const s = getOrchestrationSkill();
+    expect(s).toMatch(/cannot stop/i);
+    expect(s).not.toContain("browser_shutdown");
   });
 
   it("teaches the snapshot → act → snapshot discipline (stale refs are the #1 browser bug)", () => {

--- a/notfair-cmo/src/server/skills/orchestration-skill.ts
+++ b/notfair-cmo/src/server/skills/orchestration-skill.ts
@@ -160,9 +160,11 @@ re-verification now, only the user can give it.
 - \`browser_press\` — single key / chord (Tab, Escape, Control+a, ...).
 - \`browser_scroll\` — viewport scroll up/down/left/right.
 - \`browser_back\` — history back.
-- \`browser_shutdown\` — stop the workspace browser. Use only when the
-  user explicitly asks. Cookies persist; the next \`browser_open\`
-  relaunches with the same session.
+
+You CANNOT stop the workspace browser. Browser lifecycle belongs to the
+user (Settings → Workspace browser → Stop). This is deliberate: every
+agent in this workspace shares one Chrome, so stopping it would interrupt
+your teammates mid-task.
 
 ## Scheduling recurring work
 


### PR DESCRIPTION
## Summary

Removes \`browser_shutdown\` from the agent-facing MCP surface. With one Chrome per workspace shared by multiple agents (Greg/Ana/Mia/Sam on \`notfairco\`, etc.), any agent calling \`browser_shutdown\` would kill the browser out from under the others mid-task. The MCP description said "Use rarely" but agents pattern-match and that wasn't enforceable.

Discovered while walking through the \"4 crons fire at 9am\" concurrency scenario.

## What changes

- \`browser_shutdown\` removed from \`BROWSER_TOOLS\` registry. Agents no longer have this tool.
- Handler + input schema deleted from \`browser-tools.ts\`. \`stopBrowser\` import dropped — no longer needed there.
- Agent skill rewritten: "You CANNOT stop the workspace browser" with the multi-agent-safety reason, so agents don't go hunting for a way to "clean up" when they finish.
- Tests updated: registry count 12 → 11, plus explicit "browser_shutdown is not exposed" assertion.

## What does NOT change

- \`/api/browser/shutdown\` route is untouched. It imports \`stopBrowser\` directly from \`session.ts\`, so the Settings → Workspace browser → Stop button keeps working.
- Process-exit hooks (\`registerShutdownHooks\`) still clean up Chrome when notfair-cmo exits.

## Test plan

- [x] \`pnpm test src/server/browser src/server/mcp-server/browser-tools.test.ts src/server/skills src/app/api/browser src/components/workspace-browser-card.test.tsx\` — 141 pass / 1 skipped (E2E)
- [x] \`pnpm typecheck\` — no new errors
- [x] Verified manually that the Settings → Stop button still works (browser was launched + stopped via Settings in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)