### PR TITLE
chore(notfair-cmo): drop NOTFAIR_BROWSER_IDLE_DISABLED flag

### DIFF
--- a/notfair-cmo/src/server/browser/session.test.ts
+++ b/notfair-cmo/src/server/browser/session.test.ts
@@ -58,10 +58,10 @@ function makeFakeBrowser(): { browser: Browser; context: BrowserContext; closed:
 beforeEach(() => {
   process.env.NOTFAIR_CMO_DATA_DIR = "/tmp/notfair-cmo-test";
   process.env.NOTFAIR_CHROME_PATH = "/usr/bin/fake-chrome";
-  // Disable the idle ticker globally so tests that don't exercise it
-  // never get surprise shutdowns mid-assertion.
-  process.env.NOTFAIR_BROWSER_IDLE_DISABLED = "1";
   _sessionsByProject.clear();
+  // Cancel any leftover ticker so cross-test interactions are deterministic.
+  // The ticker fires every 30s; test durations are <1s, so we're not racing
+  // mid-test, but we still keep the slate clean.
   _stopIdleChecker();
 });
 
@@ -70,7 +70,6 @@ afterEach(async () => {
   _stopIdleChecker();
   delete process.env.NOTFAIR_CMO_DATA_DIR;
   delete process.env.NOTFAIR_CHROME_PATH;
-  delete process.env.NOTFAIR_BROWSER_IDLE_DISABLED;
   delete process.env.NOTFAIR_BROWSER_IDLE_TIMEOUT_MS;
 });
 

--- a/notfair-cmo/src/server/browser/session.ts
+++ b/notfair-cmo/src/server/browser/session.ts
@@ -14,8 +14,7 @@
  *      cached session so the next browser_open relaunches.
  *   4. Idle auto-shutdown: a 30s tick checks for sessions with no
  *      activity (no getOrLaunchBrowser call) in the last
- *      NOTFAIR_BROWSER_IDLE_TIMEOUT_MS (default 5 minutes). Disable
- *      with NOTFAIR_BROWSER_IDLE_DISABLED=1.
+ *      NOTFAIR_BROWSER_IDLE_TIMEOUT_MS (default 5 minutes).
  */
 import type { Browser, BrowserContext } from "playwright-core";
 
@@ -255,13 +254,10 @@ let _idleCheckerInterval: ReturnType<typeof setInterval> | null = null;
  * Start the periodic idle check. Idempotent — call freely. The Node
  * interval is .unref'd so it never keeps the process alive on its own.
  *
- * Disable with NOTFAIR_BROWSER_IDLE_DISABLED=1 (useful for tests that
- * want manual control, or for users who want Chrome to stay warm
- * indefinitely).
+ * Tests cancel via _stopIdleChecker() in afterEach.
  */
 export function ensureIdleChecker(): void {
   if (_idleCheckerInterval) return;
-  if (process.env.NOTFAIR_BROWSER_IDLE_DISABLED === "1") return;
   _idleCheckerInterval = setInterval(() => {
     void checkIdleSessions();
   }, IDLE_CHECK_INTERVAL_MS);


### PR DESCRIPTION
Idle auto-shutdown is the only correct behavior — keeping Chrome warm indefinitely is not a real need (1-2s relaunch is negligible, burning memory on an unused browser is strictly worse). YAGNI flag, removed.

5-min default + NOTFAIR_BROWSER_IDLE_TIMEOUT_MS override remain.

Test plan:
- [x] pnpm test src/server/browser src/server/mcp-server/browser-tools.test.ts src/app/api/browser src/components/workspace-browser-card.test.tsx → 132 pass / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)