### PR TITLE
fix(notfair): bump marketplace.json to 0.25.6 (version lockstep)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "The official Google Ads + Meta Ads + SEO + GEO plugin from NotFair. SEO, GEO, Google Ads, and Meta Ads skills for Claude Code.",
-    "version": "0.25.5"
+    "version": "0.25.6"
   },
   "plugins": [
     {
       "name": "notfair",
       "source": "./",
       "description": "The official Google Ads + Meta Ads + SEO + GEO plugin from NotFair. SEO analysis, Google Ads management, Meta (Facebook + Instagram) Ads management, GSC-driven content planning + local calendar viewer, keyword research, content optimization, schema markup, meta tags optimization, broken link checker, single-page deep audit, and Generative Engine Optimization for AI search.",
-      "version": "0.25.5",
+      "version": "0.25.6",
       "author": {
         "name": "NotFair",
         "url": "https://notfair.co"


### PR DESCRIPTION
## What

Bumps both version fields in `.claude-plugin/marketplace.json` (`metadata.version` and `plugins[0].version`) from `0.25.5` → `0.25.6`.

## Why

PR #81 (Search Console MCP) bumped `VERSION` and `.claude-plugin/plugin.json` to `0.25.6` but left `marketplace.json` at `0.25.5`. Per CLAUDE.md, all three must stay in lockstep:

> Keep `VERSION`, `plugin.json`, and `marketplace.json` in lockstep — drift causes upgrade detection bugs.

The marketplace manifest is what Claude Code reads to detect new versions, so the drift would advertise `0.25.5` while the plugin ships `0.25.6`, stalling `notfair:upgrade` for users.

## Changes

- `.claude-plugin/marketplace.json` — `metadata.version` and `plugins[0].version` → `0.25.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)