### PR TITLE
chore(release): bump NotFair to 0.9.19

### DIFF
--- a/notfair/CHANGELOG.md
+++ b/notfair/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NotFair
 
+## 0.9.19 — 2026-07-30
+
+**Remote control brings the full NotFair workspace to your phone.** Activate it from the sidebar to create a temporary Cloudflare URL protected by a private fragment-to-cookie sign-in; unauthenticated public traffic stays blocked, and stopping the session invalidates the link. Mobile navigation now exposes the same control from the workspace drawer.
+
 ## 0.9.18 — 2026-07-22
 
 **Streaming replies now stay visually quiet.** While the agent writes, chat shows only the animated **Writing the response** label—without a spinner, goal name, timer, tool subtitle, or activity history—so the status no longer competes with the response itself.

--- a/notfair/package.json
+++ b/notfair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notfair",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Goal-driven, loop-powered marketing agents that crush your business goals 24/7 — on your own machine. Say 'cut CAC to $30' and a dedicated agent turns it into a server-verified metric, then moves the number check after check while you sleep. Rides your existing Claude Code or Codex login.",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## What changed

- bumps the NotFair npm package from `0.9.18` to `0.9.19`
- adds the `0.9.19` changelog entry for secure remote control and mobile navigation

## Why

Remote control was merged in #103 after the previous release, so the package needs a patch version and user-facing release note before publication.

## User impact

The next npm release will expose the remote-control feature as NotFair `0.9.19`.

## Validation

- `pnpm typecheck`
- `node -p "require('./package.json').version"` → `0.9.19`
- `node bin/cli.mjs --version` → `0.9.19`
- `git diff --check`