### PR TITLE
fix(seo): request webmasters scope when minting ADC tokens

### DIFF
--- a/seo/seo-analysis/scripts/_gcloud.py
+++ b/seo/seo-analysis/scripts/_gcloud.py
@@ -25,3 +25,37 @@ def gcloud_command(args):
 def gcloud_run(args, *run_args, **run_kwargs):
     """Run gcloud with subprocess.run using the portable command wrapper."""
     return subprocess.run(gcloud_command(args), *run_args, **run_kwargs)
+
+
+# Search Console needs an explicitly-requested scope. Service-account ADC
+# (GOOGLE_APPLICATION_CREDENTIALS) mints a cloud-platform-only token by default,
+# which searchconsole.googleapis.com rejects with 403
+# ACCESS_TOKEN_SCOPE_INSUFFICIENT.
+GSC_SCOPES = (
+    "https://www.googleapis.com/auth/webmasters.readonly,"
+    "https://www.googleapis.com/auth/cloud-platform"
+)
+
+
+def adc_access_token(scopes=GSC_SCOPES, timeout=15):
+    """Mint an Application Default Credentials access token.
+
+    Requests `scopes` explicitly so that service-account credentials can reach
+    Search Console. User credentials that were not granted those scopes at
+    login cannot mint them, so fall back to an unscoped request rather than
+    failing outright.
+    """
+    attempts = []
+    if scopes:
+        attempts.append(
+            ["gcloud", "auth", "application-default", "print-access-token",
+             f"--scopes={scopes}"]
+        )
+    attempts.append(["gcloud", "auth", "application-default", "print-access-token"])
+
+    result = None
+    for args in attempts:
+        result = gcloud_run(args, capture_output=True, text=True, timeout=timeout)
+        if result.returncode == 0 and result.stdout.strip():
+            return result
+    return result

--- a/seo/seo-analysis/scripts/analyze_gsc.py
+++ b/seo/seo-analysis/scripts/analyze_gsc.py
@@ -21,7 +21,7 @@ import urllib.error
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, timedelta
 
-from _gcloud import gcloud_run
+from _gcloud import adc_access_token, gcloud_run
 from _uid import portable_uid, secure_write_json
 
 
@@ -57,10 +57,7 @@ def get_quota_project():
 
 def get_access_token():
     try:
-        result = gcloud_run(
-            ["gcloud", "auth", "application-default", "print-access-token"],
-            capture_output=True, text=True, timeout=15
-        )
+        result = adc_access_token()
     except FileNotFoundError:
         print("ERROR: gcloud not found. Install it and authenticate:", file=sys.stderr)
         print("  https://cloud.google.com/sdk/docs/install", file=sys.stderr)

--- a/seo/seo-analysis/scripts/list_gsc_sites.py
+++ b/seo/seo-analysis/scripts/list_gsc_sites.py
@@ -9,7 +9,7 @@ import tempfile
 import urllib.request
 import urllib.error
 
-from _gcloud import gcloud_run
+from _gcloud import adc_access_token, gcloud_run
 from _uid import portable_uid, secure_write_json
 
 
@@ -31,10 +31,7 @@ def get_quota_project():
 
 def get_access_token():
     try:
-        result = gcloud_run(
-            ["gcloud", "auth", "application-default", "print-access-token"],
-            capture_output=True, text=True, timeout=15
-        )
+        result = adc_access_token()
     except FileNotFoundError:
         print("ERROR: gcloud not found. Install it and authenticate:", file=sys.stderr)
         print("  https://cloud.google.com/sdk/docs/install", file=sys.stderr)

--- a/seo/seo-analysis/scripts/preflight.py
+++ b/seo/seo-analysis/scripts/preflight.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import urllib.request
 
-from _gcloud import gcloud_run
+from _gcloud import adc_access_token, gcloud_run
 
 
 def check_python_version():
@@ -198,10 +198,7 @@ def check_adc_credentials():
     the correct scopes.
     """
     try:
-        result = gcloud_run(
-            ["gcloud", "auth", "application-default", "print-access-token"],
-            capture_output=True, text=True, timeout=15,
-        )
+        result = adc_access_token()
     except subprocess.TimeoutExpired:
         print("ERROR: gcloud timed out checking credentials. Check your network.", file=sys.stderr)
         sys.exit(1)

--- a/seo/seo-analysis/scripts/url_inspection.py
+++ b/seo/seo-analysis/scripts/url_inspection.py
@@ -33,7 +33,7 @@ import urllib.request
 import urllib.error
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from _gcloud import gcloud_run
+from _gcloud import adc_access_token, gcloud_run
 from _uid import portable_uid, secure_write_json
 
 
@@ -55,10 +55,7 @@ def get_quota_project():
 
 def get_access_token():
     try:
-        result = gcloud_run(
-            ["gcloud", "auth", "application-default", "print-access-token"],
-            capture_output=True, text=True, timeout=15
-        )
+        result = adc_access_token()
     except FileNotFoundError:
         print("ERROR: gcloud not found. Install it from https://cloud.google.com/sdk/docs/install",
               file=sys.stderr)


### PR DESCRIPTION
## Problem

The SEO scripts mint a Google ADC access token by shelling out to:

```python
["gcloud", "auth", "application-default", "print-access-token"]
```

with no `--scopes` argument, in four places — `analyze_gsc.py`, `list_gsc_sites.py`, `url_inspection.py`, `preflight.py`.

With **user ADC** this works, because the token silently inherits whatever scopes were stored at `gcloud auth application-default login`.

With **service-account ADC** (`GOOGLE_APPLICATION_CREDENTIALS`) it does not. gcloud mints a `cloud-platform`-only token, and every Search Console call fails:

```
403 { "message": "Request had insufficient authentication scopes.",
      "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT" }
```

That makes the SEO skills unusable from any unattended or headless context. This matters because a service account is often the *only* workable credential there — Workspace orgs can enforce Cloud session-control policies that force-expire any credential built on a human's Google session, regardless of how recently it was refreshed, and a headless run has nobody present to complete the reauth prompt.

## Fix

Adds `adc_access_token()` to `_gcloud.py`. It requests `webmasters.readonly,cloud-platform` explicitly, and **falls back to an unscoped request** when the credential cannot mint those scopes — so a user ADC that was not granted them at login behaves exactly as it does today. The four scripts call it instead of shelling out individually.

The fallback is what makes this safe: it repairs the service-account path without changing the user-ADC path.

## Verification

Both credential types, against a real Search Console property:

| Path | Before | After |
|---|---|---|
| Service account (`GOOGLE_APPLICATION_CREDENTIALS` set) | `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT` | `Summary: 5 clicks \| 514 impressions \| CTR 0.97% \| Avg position 33.5` |
| User ADC without those scopes granted | "Could not get access token. Run: gcloud auth…" | identical message, no regression |

Also ruled out as alternatives, in case they come up in review: the `CLOUDSDK_AUTH_SCOPES` environment variable has no effect on ADC token minting, and `gcloud config set auth/scopes` errors with `Section [auth] has no property [scopes]`. A code change is the only route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)