### PR TITLE
fix: preserve LF for Bash helpers on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+bin/notfair-change-watch text eol=lf
+bin/notfair-config text eol=lf
+bin/notfair-update-check text eol=lf

--- a/test/unit/test_shell_line_endings.py
+++ b/test/unit/test_shell_line_endings.py
@@ -1,0 +1,18 @@
+"""Bash entrypoints must remain runnable in Windows checkouts."""
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPERS = [
+    "bin/notfair-change-watch",
+    "bin/notfair-config",
+    "bin/notfair-update-check",
+]
+
+
+@pytest.mark.parametrize("relative_path", HELPERS)
+def test_bash_helper_uses_lf(relative_path):
+    assert b"\r\n" not in (ROOT / relative_path).read_bytes()


### PR DESCRIPTION
Closes #102.

Windows checkouts with `core.autocrlf=true` convert the extensionless Bash helpers to CRLF, which breaks their execution. Add LF attributes for the three helpers and `*.sh`, plus a regression check for the helper bytes.

Validation: the three checks fail on the original Windows checkout and pass with the attributes. A fresh `git -c core.autocrlf=true checkout-index` export produces LF for all three helpers and `test/install.test.sh`. The existing install suite passes under WSL: **308 passed, 0 failed**. The helper source files themselves have no content changes.
